### PR TITLE
feat: Add missing pull request tools

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -317,7 +317,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "list_pull_requests": {
         const args = pulls.ListPullRequestsSchema.parse(request.params.arguments);
-        const pullRequests = await pulls.listPullRequests(args);
+        const { owner, repo, ...options } = args;
+        const pullRequests = await pulls.listPullRequests(owner, repo, options);
         return {
           content: [{ type: "text", text: JSON.stringify(pullRequests, null, 2) }],
         };
@@ -325,7 +326,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "create_pull_request_review": {
         const args = pulls.CreatePullRequestReviewSchema.parse(request.params.arguments);
-        const review = await pulls.createPullRequestReview(args);
+        const { owner, repo, pull_number, ...options } = args;
+        const review = await pulls.createPullRequestReview(owner, repo, pull_number, options);
         return {
           content: [{ type: "text", text: JSON.stringify(review, null, 2) }],
         };
@@ -333,7 +335,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "merge_pull_request": {
         const args = pulls.MergePullRequestSchema.parse(request.params.arguments);
-        const result = await pulls.mergePullRequest(args);
+        const { owner, repo, pull_number, ...options } = args;
+        const result = await pulls.mergePullRequest(owner, repo, pull_number, options);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
@@ -357,7 +360,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "update_pull_request_branch": {
         const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
-        const result = await pulls.updatePullRequestBranch(args);
+        const { owner, repo, pull_number, expected_head_sha } = args;
+        const result = await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -25,12 +25,11 @@ import {
   GitHubConflictError,
   isGitHubError,
 } from './common/errors.js';
-import { VERSION } from "./common/version.js";
 
 const server = new Server(
   {
     name: "github-mcp-server",
-    version: VERSION,
+    version: "0.1.0",
   },
   {
     capabilities: {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -25,11 +25,12 @@ import {
   GitHubConflictError,
   isGitHubError,
 } from './common/errors.js';
+import { VERSION } from "./common/version.js";
 
 const server = new Server(
   {
     name: "github-mcp-server",
-    version: "0.1.0",
+    version: VERSION,
   },
   {
     capabilities: {
@@ -40,7 +41,7 @@ const server = new Server(
 
 function formatGitHubError(error: GitHubError): string {
   let message = `GitHub API Error: ${error.message}`;
-  
+
   if (error instanceof GitHubValidationError) {
     message = `Validation Error: ${error.message}`;
     if (error.response) {
@@ -98,6 +99,51 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "create_pull_request",
         description: "Create a new pull request in a GitHub repository",
         inputSchema: zodToJsonSchema(pulls.CreatePullRequestSchema),
+      },
+      {
+        name: "get_pull_request",
+        description: "Get details of a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
+      },
+      {
+        name: "list_pull_requests",
+        description: "List and filter repository pull requests",
+        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
+      },
+      {
+        name: "create_pull_request_review",
+        description: "Create a review on a pull request",
+        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the list of files changed in a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the combined status of all status checks for a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get the review comments on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get the reviews on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
       },
       {
         name: "fork_repository",
@@ -258,6 +304,78 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const pullRequest = await pulls.createPullRequest(args);
         return {
           content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
+        };
+      }
+
+      case "get_pull_request": {
+        const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
+        const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
+        };
+      }
+
+      case "list_pull_requests": {
+        const args = pulls.ListPullRequestsSchema.parse(request.params.arguments);
+        const pullRequests = await pulls.listPullRequests(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequests, null, 2) }],
+        };
+      }
+
+      case "create_pull_request_review": {
+        const args = pulls.CreatePullRequestReviewSchema.parse(request.params.arguments);
+        const review = await pulls.createPullRequestReview(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(review, null, 2) }],
+        };
+      }
+
+      case "merge_pull_request": {
+        const args = pulls.MergePullRequestSchema.parse(request.params.arguments);
+        const result = await pulls.mergePullRequest(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_files": {
+        const args = pulls.GetPullRequestFilesSchema.parse(request.params.arguments);
+        const files = await pulls.getPullRequestFiles(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_status": {
+        const args = pulls.GetPullRequestStatusSchema.parse(request.params.arguments);
+        const status = await pulls.getPullRequestStatus(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+        };
+      }
+
+      case "update_pull_request_branch": {
+        const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
+        const result = await pulls.updatePullRequestBranch(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_comments": {
+        const args = pulls.GetPullRequestCommentsSchema.parse(request.params.arguments);
+        const comments = await pulls.getPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_reviews": {
+        const args = pulls.GetPullRequestReviewsSchema.parse(request.params.arguments);
+        const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
         };
       }
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -361,9 +361,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "update_pull_request_branch": {
         const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
         const { owner, repo, pull_number, expected_head_sha } = args;
-        const result = await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
+        await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify({ success: true }, null, 2) }],
         };
       }
 


### PR DESCRIPTION
This PR adds the missing pull request-related tools that were documented in README.md but not implemented in the code. Added tools include:

- `get_pull_request`
- `list_pull_requests`
- `create_pull_request_review`
- `merge_pull_request`
- `get_pull_request_files`
- `get_pull_request_status`
- `update_pull_request_branch`
- `get_pull_request_comments`
- `get_pull_request_reviews`

Each tool has been implemented with:
- Tool registration in the ListToolsRequestSchema handler
- Handler implementation in the CallToolRequestSchema handler
- Proper schema validation and error handling
- Consistent response formatting

This change brings the implementation in line with the documentation and provides a more complete set of pull request management capabilities.