### PR TITLE
feat(github): Implement branch deletion functionality

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -156,6 +156,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: zodToJsonSchema(branches.CreateBranchSchema),
       },
       {
+        name: "delete_branch",
+        description: "Delete a branch in a GitHub repository",
+        inputSchema: zodToJsonSchema(branches.DeleteBranchSchema),
+      },
+      {
         name: "list_commits",
         description: "Get list of commits of a branch in a GitHub repository",
         inputSchema: zodToJsonSchema(commits.ListCommitsSchema)
@@ -224,6 +229,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         );
         return {
           content: [{ type: "text", text: JSON.stringify(branch, null, 2) }],
+        };
+      }
+
+      case "delete_branch": {
+        const args = branches.DeleteBranchSchema.parse(request.params.arguments);
+        await branches.deleteBranch(args.owner, args.repo, args.branch);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: true, branch: args.branch }, null, 2) }],
         };
       }
 
@@ -361,9 +374,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "update_pull_request_branch": {
         const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
         const { owner, repo, pull_number, expected_head_sha } = args;
-        await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
+        const result = await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
         return {
-          content: [{ type: "text", text: JSON.stringify({ success: true }, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          status: 202
         };
       }
 

--- a/src/github/operations/branches.ts
+++ b/src/github/operations/branches.ts
@@ -15,6 +15,12 @@ export const CreateBranchSchema = z.object({
   from_branch: z.string().optional().describe("Optional: source branch to create from (defaults to the repository's default branch)"),
 });
 
+export const DeleteBranchSchema = z.object({
+  owner: z.string().describe("Repository owner (username or organization)"),
+  repo: z.string().describe("Repository name"),
+  branch: z.string().describe("Name of the branch to delete"),
+});
+
 // Type exports
 export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 
@@ -109,4 +115,17 @@ export async function updateBranch(
   );
 
   return GitHubReferenceSchema.parse(response);
+}
+
+export async function deleteBranch(
+  owner: string,
+  repo: string,
+  branch: string
+): Promise<void> {
+  await githubRequest(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+    {
+      method: "DELETE",
+    }
+  );
 }


### PR DESCRIPTION
# Add Delete Branch Tool

This PR adds a new tool for deleting branches in GitHub repositories. The changes include:

## Features
- Added `delete_branch` tool definition in the tools list
- Implemented `deleteBranch` function in branches operations
- Added Zod schema for delete branch parameters

## Technical Changes
- Added DELETE endpoint handler for `/repos/{owner}/{repo}/git/refs/heads/{branch}`
- Updated types and exports for branch operations
- Fixed PR branch update response handling to include status code

## Testing
The implementation matches GitHub's REST API specification for deleting branches.