### PR TITLE
feat: Add support for published_artifact_url in file operations

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -20,6 +20,7 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `repo` (string): Repository name
      - `path` (string): Path where to create/update the file
      - `content` (string): Content of the file
+     - `published_artifact_url` (optional string): Public URL of a published artifact, which contains the file content in a single <code> block
      - `message` (string): Commit message
      - `branch` (string): Branch to create/update the file in
      - `sha` (optional string): SHA of file being replaced (for updates)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -67,7 +67,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "create_or_update_file",
-        description: "Create or update a single file in a GitHub repository",
+        description: "Create or update a single file in a GitHub repository. For larger files, use " +
+          "'published_artifact_url' instead of 'content'. The URL should point to a published artifact " +
+          "containing the file content in a single <code> block. Note: The user must manually publish " +
+          "the artifact and provide the resulting URL; it cannot be generated automatically.",
         inputSchema: zodToJsonSchema(files.CreateOrUpdateFileSchema),
       },
       {
@@ -280,6 +283,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.repo,
           args.path,
           args.content,
+          args.published_artifact_url,
           args.message,
           args.branch,
           args.sha


### PR DESCRIPTION
🤖 *This PR description has been enhanced by **[Claude for Desktop](https://claude.ai/download)** via their **[MCP](https://www.anthropic.com/news/model-context-protocol)** **[Github](https://github.com/modelcontextprotocol/servers/tree/main?tab=readme-ov-file#-reference-servers)** tool.*

---

This PR adds support for handling large file content through published artifacts in the Model Context Protocol GitHub server.

### Changes
- Added `published_artifact_url` parameter to `create_or_update_file` operation
- Enhanced input validation to ensure either `content` or `published_artifact_url` is provided (but not both)
- Implemented HTML entity decoding for artifact content retrieval
- Updated documentation in README.md

### Implementation Details
- The new parameter allows fetching file content from a published artifact URL instead of passing it directly
- Content is extracted from the first `<code>` block found in the artifact
- HTML entities in the code block are properly decoded before file creation/update
- Added comprehensive schema validation to ensure proper parameter usage

### Testing
Before merging, please verify:
- [ ] File creation using direct content still works
- [ ] File creation using published artifact URL works
- [ ] HTML entity decoding functions correctly
- [ ] Error handling for invalid/missing code blocks works as expected